### PR TITLE
adds ticket counter for players in neutral sector matches

### DIFF
--- a/FNF_MissionTemplate.VR/modes/neutralsector/neutralSector.sqf
+++ b/FNF_MissionTemplate.VR/modes/neutralsector/neutralSector.sqf
@@ -23,6 +23,9 @@ switch (_numberOfSectors) do {
   };
 };
 
+//Show ticket counter
+[] call BIS_fnc_showMissionStatus;
+
 _win = {
   phx_gameEnd = true;
   publicVariable "phx_gameEnd";


### PR DESCRIPTION
Currently no status display for players during nSector game mode, so they won't see when they're capture / the status of objectives / point counts. It's in spectator, but not while playing.